### PR TITLE
check explicitly if hostmanager.ignore_private_ip is set to true

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file.rb
+++ b/lib/vagrant-hostmanager/hosts_file.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
         # define a lambda for looking up a machine's ip address
         get_ip_address = lambda do |machine|
           ip = nil
-          unless machine.config.hostmanager.ignore_private_ip
+          if machine.config.hostmanager.ignore_private_ip != true
             machine.config.vm.networks.each do |network|
               key, options = network[0], network[1]
               ip = options[:ip] if key == :private_network


### PR DESCRIPTION
As `vagrant hostmanager` (in contrary to eg. `vagrant provision`) doesn't implicate config finalization and validation, hostmanager.ignore_private_ip is never set to false in such a case. It is just an object

``` ruby
class Config
# [...]
  UNSET_VALUE = Object.new
```

and the below statement

``` ruby
unless machine.config.hostmanager.ignore_private_ip
```

results in `false`, causing the plugin to ignore private ip when the option is not set at all.

It would be probably better to force `vagrant hostmanager` to `finalize!` and `validate` the configuration, but I couldn't figure it out yet.
