### PR TITLE
Use hostmaster as provisioner.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ Vagrant.configure("2") do |config|
 end
 ```
 
+As a last option, you can also choose hostmanager as a provisioner.
+This allows you to use the provisioning order to ensure that hostmanager
+runs before or after provisioning:
+
+```ruby
+Vagrant.configure("2") do |config|
+  ...
+  ## Cut box configurations ##
+
+  # Run hostmanager before the shell provisioner
+  vm_config.vm.provision :hostmanager
+  vm_config.vm.provision :shell do |shell|
+    shell.path = 'foo/bar.sh'
+  end
+end
+```
+
 Contribute
 ----------
 Contributions are welcome.

--- a/lib/vagrant-hostmanager/plugin.rb
+++ b/lib/vagrant-hostmanager/plugin.rb
@@ -7,6 +7,8 @@ module VagrantPlugins
       description <<-DESC
         This plugin manages the /etc/hosts file for guest machines. An entry is
         created for each active machine using the hostname attribute.
+
+        You can also use the hostmanager provisioner to update the hosts file.
       DESC
 
       config(:hostmanager) do
@@ -20,6 +22,11 @@ module VagrantPlugins
 
       action_hook(:hostmanager, :machine_action_destroy) do |hook|
         hook.append(Action::UpdateHostsFile)
+      end
+
+      provisioner(:hostmanager) do
+        require_relative 'provisioner'
+        Provisioner
       end
 
       command(:hostmanager) do

--- a/lib/vagrant-hostmanager/provisioner.rb
+++ b/lib/vagrant-hostmanager/provisioner.rb
@@ -1,0 +1,12 @@
+module VagrantPlugins
+  module HostManager
+    class Provisioner < Vagrant.plugin('2', :provisioner)
+      include HostsFile
+
+      def provision
+         update(@machine)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Very basic implementation but can be used to force hostmanager update
s before/after provisioning depending on the provisioning order.

Usage:

``` ruby
  vm_config.vm.provision :hostmanager
  vm_config.vm.provision :shell do |shell|
    shell.path = 'foo/bar.sh'
  end
```
