### PR TITLE
Fix typo in config.rb.

### DIFF
--- a/lib/vagrant-hostmanager/config.rb
+++ b/lib/vagrant-hostmanager/config.rb
@@ -21,7 +21,7 @@ module VagrantPlugins
 
       def finalize!
         @enabled = false if @enabled == UNSET_VALUE
-        @manage_host = false if @managed_host == UNSET_VALUE
+        @manage_host = false if @manage_host == UNSET_VALUE
         @ignore_private_ip = false if @ignore_private_ip == UNSET_VALUE
         @include_offline = false if @include_offline == UNSET_VALUE
         @aliases = [ @aliases ].flatten


### PR DESCRIPTION
When I updated my local branch to the 1.0.0 version, I started getting

HostManager configuration:
- A value for hostmanager.manage_host can only be true or false, not type 'Object'

Looks like it was resulting from a typo in config.rb.
