### PR TITLE
- Set hook to run before provisioner so that provisioners that need to c...

### DIFF
--- a/lib/vagrant-hostmanager/action/update_all.rb
+++ b/lib/vagrant-hostmanager/action/update_all.rb
@@ -15,8 +15,6 @@ module VagrantPlugins
         end
 
         def call(env)
-          # skip if machine is already active on up action
-          return @app.call(env) if @machine.id && env[:machine_action] == :up
           # skip if machine is not active on destroy action
           return @app.call(env) if !@machine.id && env[:machine_action] == :destroy
 

--- a/lib/vagrant-hostmanager/plugin.rb
+++ b/lib/vagrant-hostmanager/plugin.rb
@@ -16,6 +16,10 @@ module VagrantPlugins
         Config
       end
 
+      action_hook(self::ALL_ACTIONS) do |hook|
+          hook.after(Vagrant::Action::Builtin::SetHostname, Action.update_all)
+      end
+
       action_hook(:hostmanager, :machine_action_up) do |hook|
         hook.prepend(Action.update_all)
       end


### PR DESCRIPTION
...ommunicate to other hosts in the configuration can run.
- Don't prevent hook from running when guest is already up. The operation should be idempotent. This was also interfering with setting hostname before the provisioner.

Use case for this is:
1) Bringing up a vagrant puppet master
2) Bring up a machine that's communicating with the puppet master by hostname during the provisioning stage. If the hostname isn't set, the action will hang or fail.
