### PR TITLE
Add hooks & define active/offline as running/not

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ command:
 
     $ vagrant hostmanager
 
-The plugin may hook into the `vagrant up` and `vagrant destroy` commands
-automatically. When a machine is created or destroyed, all active
+The plugin hooks into the `vagrant up`, `vagrant destroy`, `vagrant halt`,
+`vagrant resume` and `vagrant suspend` commands automatically.
+When a machine enters or exits the running state , all active
 machines with the same provider will have their `/etc/hosts` file updated
 accordingly. Set the `hostmanager.enabled` attribute to `true` in the
 Vagrantfile to activate this behavior.

--- a/lib/vagrant-hostmanager/action/update_all.rb
+++ b/lib/vagrant-hostmanager/action/update_all.rb
@@ -15,10 +15,14 @@ module VagrantPlugins
         end
 
         def call(env)
-          # skip if machine is already active on up action
-          return @app.call(env) if @machine.id && env[:machine_action] == :up
-          # skip if machine is not active on destroy action
-          return @app.call(env) if !@machine.id && env[:machine_action] == :destroy
+          # skip if machine is running and the action is resume or up
+          return @app.call(env) if @machine.state.id == :running && [:resume, :up].include?(env[:machine_action])
+          # skip if machine is not running and the action is destroy, halt or suspend
+          return @app.call(env) if @machine.state.id != :running && [:destroy, :halt, :suspend].include?(env[:machine_action])
+          # skip if machine is not saved and the action is resume
+          return @app.call(env) if @machine.state.id != :saved && env[:machine_action] == :resume
+          # skip if machine is not running and the action is suspend
+          return @app.call(env) if @machine.state.id != :running && env[:machine_action] == :suspend
 
           # check config to see if the hosts file should be update automatically
           return @app.call(env) unless @machine.config.hostmanager.enabled?

--- a/lib/vagrant-hostmanager/hosts_file.rb
+++ b/lib/vagrant-hostmanager/hosts_file.rb
@@ -72,20 +72,19 @@ module VagrantPlugins
       end
 
       def get_machines
-        # check if offline machines should be included in host entries
-        if @global_env.config_global.hostmanager.include_offline?
-          machines = []
-          @global_env.machine_names.each do |name|
-            begin
-              @global_env.machine(name, @provider)
+        machines = []
+        @global_env.machine_names.each do |name|
+          begin
+            machine = @global_env.machine(name, @provider)
+
+            # check if offline machines should be included in host entries
+            if @global_env.config_global.hostmanager.include_offline? || machine.state.id == :running 
               machines << [name, @provider]
-            rescue Vagrant::Errors::MachineNotFound
             end
+          rescue Vagrant::Errors::MachineNotFound
           end
-          machines
-        else
-          @global_env.active_machines
         end
+        machines
       end
 
     end

--- a/lib/vagrant-hostmanager/plugin.rb
+++ b/lib/vagrant-hostmanager/plugin.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
       name 'HostManager'
       description <<-DESC
         This plugin manages the /etc/hosts file for the host and guest machines.
-        An entry is created for each active machine using the hostname attribute.
+        An entry is created for each running machine using the hostname attribute.
 
         You can also use the hostmanager provisioner to update the hosts file.
       DESC
@@ -21,6 +21,18 @@ module VagrantPlugins
       end
 
       action_hook(:hostmanager, :machine_action_destroy) do |hook|
+        hook.prepend(Action.update_all)
+      end
+
+      action_hook(:hostmanager, :machine_action_halt) do |hook|
+        hook.prepend(Action.update_all)
+      end
+
+      action_hook(:hostmanager, :machine_action_resume) do |hook|
+        hook.prepend(Action.update_all)
+      end
+
+      action_hook(:hostmanager, :machine_action_suspend) do |hook|
         hook.prepend(Action.update_all)
       end
 


### PR DESCRIPTION
Hosts entries shouldn't only be added/removed upon creation/destruction.
The persistence of /etc/hosts entries while a vm is in a halted or
suspended state is undesirable especially when hostmanager.manage_host
is set to true. That would mean your host's /etc/hosts would retain
entries even if you aren't currently using a vm.  The vm would have to
be destroyed for the entry to be removed from the host's /etc/hosts.

Adding hooks for halt, resume and suspend commands and changing the
concept of active and offline states from created or not_created to
running or not running allows a vm's entry to be added when it is put
in a running state and removed when it is not running.

The hostmanager.include_offline can be set to true if one still desires
to have not_created or not running machines' entries included in the
/etc/hosts file.
