### PR TITLE
Check global.enabled instead of machine.enabled

### DIFF
--- a/lib/vagrant-hostmanager/action/update_all.rb
+++ b/lib/vagrant-hostmanager/action/update_all.rb
@@ -21,7 +21,7 @@ module VagrantPlugins
           return @app.call(env) if !@machine.id && env[:machine_action] == :destroy
 
           # check config to see if the hosts file should be update automatically
-          return @app.call(env) unless @machine.config.hostmanager.enabled?
+          return @app.call(env) unless @global_env.config_global.hostmanager.enabled?
           @logger.info 'Updating /etc/hosts file automatically'
 
           @app.call(env)


### PR DESCRIPTION
update_all.rb checks if @machine.config.hostmanager.enabled is set to true.
The default value of @enabled is set to false by config.rb.
If the Vagrantfile has a global value of true for enabled but it sets vm
specific hostmanager options, such as when specifying hostmanager.aliases,
then the @machine.config.hostmanager.enabled will default to false and
hostmanager will not think it is enabled.

Check @global_env.config_global.hostmanager.enabled instead.
