### PR TITLE
fixed windows compatibility issues for the hosts file

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file.rb
+++ b/lib/vagrant-hostmanager/hosts_file.rb
@@ -14,17 +14,29 @@ module VagrantPlugins
         # upload modified file and remove temporary file
         machine.communicate.upload(file, '/tmp/hosts')
         machine.communicate.sudo('mv /tmp/hosts /etc/hosts')
-        FileUtils.rm(file)
+        # i have no idea if this is a windows competibility issue or not, but sometimes it dosen't work on my machine
+        begin
+          FileUtils.rm(file) 
+        rescue Exception => e
+        end
       end
 
       def update_host
         # copy and modify hosts file on host with Vagrant-managed entries
         file = @global_env.tmp_path.join('hosts.local')
-        FileUtils.cp('/etc/hosts', file)
+        # add a "if windows..."
+        hosts_location = '/etc/hosts'
+        copy_cmd = 'sudo cp'
+        # handles the windows hosts file...
+        if ENV['OS'] == 'Windows_NT'
+          hosts_location = "#{ENV['WINDIR']}\\System32\\drivers\\etc\\hosts"
+          copy_cmd = 'cp'
+        end
+        FileUtils.cp(hosts_location, file)
         update_file(file)
 
         # copy modified file using sudo for permission
-        `sudo cp #{file} /etc/hosts`
+        `#{copy_cmd} #{file} #{hosts_location}`
       end
 
       private


### PR DESCRIPTION
hi Shawn, great job on this plugin :)

I found some windows compatibility issue that i fixed.
the hostsfile::update_host didn't deal with a windows based environment, so i added a small if statement.
another thing, that might be a windows thing, but i have no idea, because on a single-vm it worked, but when i added more VMs, it started to happen... in hostfile::update_guest i got error on FileUtils.rm that says that there is no file/directory on the /etc/hosts file. so i added a rescue statement.

i forgot to add it to the request, but the en.yml file need to be updated:
update_host: "Updating /etc/hosts file on host machine (password may be required, on windows run cmd in administrator mode)..."
