### PR TITLE
Properly convert provider command option to symbol

### DIFF
--- a/lib/vagrant-hostmanager/command.rb
+++ b/lib/vagrant-hostmanager/command.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
 
           o.on('--provider provider', String,
             'Update machines with the specific provider.') do |provider|
-            options[:provider] = provider
+            options[:provider] = provider.to_sym
           end
         end
 


### PR DESCRIPTION
Without proper casting the following check fail:

https://github.com/smdahlen/vagrant-hostmanager/blob/master/lib/vagrant-hostmanager/hosts_file.rb#L59

This makes the command ineffective when a provider different from Virtualbox is used.
