### PR TITLE
Add aliases_only option

### DIFF
--- a/lib/vagrant-hostmanager/config.rb
+++ b/lib/vagrant-hostmanager/config.rb
@@ -5,6 +5,7 @@ module VagrantPlugins
       attr_accessor :manage_host
       attr_accessor :ignore_private_ip
       attr_accessor :aliases
+      attr_accessor :aliases_only
       attr_accessor :include_offline
 
       alias_method :enabled?, :enabled
@@ -17,6 +18,7 @@ module VagrantPlugins
         @ignore_private_ip = UNSET_VALUE
         @include_offline = UNSET_VALUE
         @aliases = []
+        @aliases_only = UNSET_VALUE
       end
 
       def finalize!
@@ -24,11 +26,13 @@ module VagrantPlugins
         @ignore_private_ip = false if @ignore_private_ip == UNSET_VALUE
         @include_offline = false if @include_offline == UNSET_VALUE
         @aliases = [ @aliases ].flatten
+        @aliases_only = false if @aliases_only == UNSET_VALUE
       end
 
       def validate(machine)
         errors = []
 
+        errors << validate_bool('hostmanager.aliases_only', @aliases_only)
         errors << validate_bool('hostmanager.enabled', @enabled)
         errors << validate_bool('hostmanager.manage_host', @manage_host)
         errors << validate_bool('hostmanager.ignore_private_ip', @ignore_private_ip)
@@ -41,6 +45,10 @@ module VagrantPlugins
             :config_key => 'hostmanager.aliases',
             :is_class   => aliases.class.to_s,
           })
+        end
+
+        if machine.config.hostmanager.aliases_only && machine.config.hostmanager.aliases.empty?
+          errors << I18n.t('vagrant_hostmanager.config.aliases_required')
         end
 
         { 'HostManager configuration' => errors }

--- a/lib/vagrant-hostmanager/hosts_file.rb
+++ b/lib/vagrant-hostmanager/hosts_file.rb
@@ -58,11 +58,16 @@ module VagrantPlugins
         get_machines.each do |name, p|
           if @provider == p
             machine = @global_env.machine(name, p)
-            host = machine.config.vm.hostname || name
+            entry  = ""
+            entry += "#{get_ip_address(machine)}\t"
+            unless machine.config.hostmanager.aliases_only
+              host = machine.config.vm.hostname || name
+              entry += host              
+            end
+            entry += machine.config.hostmanager.aliases.join(' ').chomp
             id = machine.id
-            ip = get_ip_address(machine)
-            aliases = machine.config.hostmanager.aliases.join(' ').chomp
-            entries <<  "#{ip}\t#{host} #{aliases}\t# VAGRANT ID: #{id}\n"
+            entry += "\t# VAGRANT ID: #{id}\n"
+            entries <<  entry
             ids << id unless ids.include?(id)
           end
         end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,5 +5,6 @@ en:
       update_guest: "[%{name}] Updating /etc/hosts file..."
       update_host: "Updating /etc/hosts file on host machine (password may be required)..."
     config:
+      aliases_required: "A value for hostmanager.aliases is required, since hostmanager.aliases_only is true"
       not_a_bool: "A value for %{config_key} can only be true or false, not type '%{value}'"
       not_an_array_or_string: "A value for %{config_key} must be an Array or String, not type '%{is_class}'"


### PR DESCRIPTION
This option allow to write just the aliases in the hosts file, skipping the main hostname.

Also, if enabled, it verifies that some valid value for the aliases option is present.
