### PR TITLE
Allow ip resolver to know for which vm other vm is being resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ where host name is stored in ssh_info hash of each machine.
 This causes generation of invalid /etc/hosts file.
 
 Custom IP resolver gives you oportunity to calculate IP address
-for each machine by yourself. For example:
+for each machine by yourself, giving You also access to the machine that is
+updating /etc/hosts. For example:
 
 ```ruby
-config.hostmanager.ip_resolver = proc do |vm|
+config.hostmanager.ip_resolver = proc do |vm, resolving_vm|
   if hostname = (vm.ssh_info && vm.ssh_info[:host])
     `host #{hostname}`.split("\n").last[/(\d+\.\d+\.\d+\.\d+)/, 1]
   end

--- a/lib/vagrant-hostmanager/hosts_file.rb
+++ b/lib/vagrant-hostmanager/hosts_file.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
         # download and modify file with Vagrant-managed entries
         file = @global_env.tmp_path.join("hosts.#{machine.name}")
         machine.communicate.download(realhostfile, file)
-        update_file(machine, file)
+        update_file(file, machine)
 
         # upload modified file and remove temporary file
         machine.communicate.upload(file, '/tmp/hosts')
@@ -49,13 +49,13 @@ module VagrantPlugins
         end
 
         FileUtils.cp(hosts_location, file)
-        update_file(nil, file)
+        update_file(file)
         copy_proc.call
       end
 
       private
 
-      def update_file(current_machine, file)
+      def update_file(file, resolving_machine=nil)
         # build array of host file entries from Vagrant configuration
         entries = []
         destroyed_entries = []
@@ -65,7 +65,7 @@ module VagrantPlugins
             machine = @global_env.machine(name, p)
             host = machine.config.vm.hostname || name
             id = machine.id
-            ip = get_ip_address(current_machine, machine)
+            ip = get_ip_address(machine, resolving_machine)
             aliases = machine.config.hostmanager.aliases.join(' ').chomp
             if id.nil?
               destroyed_entries << "#{ip}\t#{host} #{aliases}"
@@ -94,10 +94,10 @@ module VagrantPlugins
         end
       end
 
-      def get_ip_address(current_machine, machine)
+      def get_ip_address(machine, resolving_machine)
         custom_ip_resolver = machine.config.hostmanager.ip_resolver
         if custom_ip_resolver
-          custom_ip_resolver.call(current_machine, machine)
+          custom_ip_resolver.call(machine, resolving_machine)
         else
           ip = nil
           if machine.config.hostmanager.ignore_private_ip != true


### PR DESCRIPTION
Such feature is needed, in case we would like to resolve ip addresses in different way depending which node resolves other nodes.
##### Sample use case

When setting up cluster across different regions (in EC2 or eucalyptus) we would like to resolve nodes within the same region by private ip, and nodes that are in different region by public ip and therefore we need information which node is resolving which one.
