### PR TITLE
fix ip assignation for hostmanager resolution

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file.rb
+++ b/lib/vagrant-hostmanager/hosts_file.rb
@@ -97,7 +97,7 @@ module VagrantPlugins
       def get_ip_address(machine)
         custom_ip_resolver = machine.config.hostmanager.ip_resolver
         if custom_ip_resolver
-          custom_ip_resolver.call(machine)
+          ip = custom_ip_resolver.call(machine)
         else
           ip = nil
           if machine.config.hostmanager.ignore_private_ip != true


### PR DESCRIPTION
The IP for custom resolver is not assigned leading the custom ip_resolver to assign thing to nothing.
therefor the ssh_info is always used. 
this structure being readonly, we cannot use it to resolve the ip easer.
