### PR TITLE
Fix for windows guests running on non-windows hosts.

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file.rb
+++ b/lib/vagrant-hostmanager/hosts_file.rb
@@ -10,11 +10,9 @@ module VagrantPlugins
           realhostfile = '/etc/inet/hosts'
           move_cmd = 'mv'
         elsif (machine.communicate.test("test -d $Env:SystemRoot"))
-          windir = nil
+          windir = ""
           machine.communicate.execute("echo %SYSTEMROOT%", {:shell => :cmd}) do |type, contents|
-            if type == :stdout
-              windir = contents.gsub("\r\n", '')
-            end
+            windir << contents.gsub("\r\n", '') if type == :stdout
           end
           realhostfile = "#{windir}\\System32\\drivers\\etc\\hosts"
           move_cmd = 'mv -force'


### PR DESCRIPTION
Pending https://github.com/WinRb/vagrant-windows/pull/169, this will get windows guests fully operational on non-windows hosts.  ENV['WINDIR'] will only be present if the host machine is Windows.  This retrieves the environment variable from the guest.
