### PR TITLE
Hotfix/machine not found

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file.rb
+++ b/lib/vagrant-hostmanager/hosts_file.rb
@@ -62,17 +62,20 @@ module VagrantPlugins
         ids = []
         get_machines.each do |name, p|
           if @provider == p
-            machine = @global_env.machine(name, p)
-            host = machine.config.vm.hostname || name
-            id = machine.id
-            ip = get_ip_address(machine, resolving_machine)
-            aliases = machine.config.hostmanager.aliases.join(' ').chomp
-            if id.nil?
-              destroyed_entries << "#{ip}\t#{host} #{aliases}"
-            else
-              entries <<  "#{ip}\t#{host} #{aliases}\t# VAGRANT ID: #{id}\n"
-              ids << id unless ids.include?(id)
-            end
+            begin
+              machine = @global_env.machine(name, p)
+              host = machine.config.vm.hostname || name
+              id = machine.id
+              ip = get_ip_address(machine, resolving_machine)
+              aliases = machine.config.hostmanager.aliases.join(' ').chomp
+              if id.nil?
+                destroyed_entries << "#{ip}\t#{host} #{aliases}"
+              else
+                entries <<  "#{ip}\t#{host} #{aliases}\t# VAGRANT ID: #{id}\n"
+                ids << id unless ids.include?(id)
+              end
+            rescue Vagrant::Errors::MachineNotFound
+            end  
           end
         end
 


### PR DESCRIPTION
It happens that sometimes I have some active machines (there are still in .vagrant/...), that are no longer in Vagrantfile, hostmanager is taking them into consideration which causes vagrant itself to fail, raising error that machine is not found.

It's rather quick fix, verified and is ignoring machine not existing in Vagrantfile
