### PR TITLE
Check that the IP is set before adding a new line to the hosts file

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file.rb
+++ b/lib/vagrant-hostmanager/hosts_file.rb
@@ -80,7 +80,9 @@ module VagrantPlugins
         ip = get_ip_address(machine, resolving_machine)
         host = machine.config.vm.hostname || machine.name
         aliases = machine.config.hostmanager.aliases.join(' ').chomp
-        "#{ip}\t#{host} #{aliases}\n"
+        if ip != nil
+          "#{ip}\t#{host} #{aliases}\n"
+        end
       end
 
       def get_ip_address(machine, resolving_machine)

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -33,4 +33,9 @@ Vagrant.configure('2') do |config|
     server.vm.network :private_network, :ip => '10.0.5.4'
     server.vm.provision :hostmanager
   end
+
+  config.vm.define :server4 do |server|
+    server.vm.hostname = 'scruffy'
+    server.vm.provision :hostmanager
+  end
 end


### PR DESCRIPTION
If there is no interface (or no IP address available), hostmanager will add a line starting with `\t` followed by the name of the machine. Instead it should just ignore the entire line
