### PR TITLE
extract old vagrant version compatibility code into util method

### DIFF
--- a/lib/vagrant-hostmanager/action/update_all.rb
+++ b/lib/vagrant-hostmanager/action/update_all.rb
@@ -1,4 +1,5 @@
 require 'vagrant-hostmanager/hosts_file'
+require 'vagrant-hostmanager/util'
 
 module VagrantPlugins
   module HostManager
@@ -11,14 +12,7 @@ module VagrantPlugins
           @machine = env[:machine]
           @global_env = @machine.env
           @provider = @machine.provider_name
-
-          # config_global is deprecated from v1.5
-          if Gem::Version.new(::Vagrant::VERSION) >= Gem::Version.new('1.5')
-            @config = @global_env.vagrantfile.config
-          else
-            @config = @global_env.config_global
-          end
-
+          @config = Util.get_config(@global_env)
           @logger = Log4r::Logger.new('vagrant::hostmanager::update_all')
         end
 

--- a/lib/vagrant-hostmanager/action/update_guest.rb
+++ b/lib/vagrant-hostmanager/action/update_guest.rb
@@ -1,4 +1,5 @@
 require 'vagrant-hostmanager/hosts_file'
+require 'vagrant-hostmanager/util'
 
 module VagrantPlugins
   module HostManager
@@ -11,14 +12,7 @@ module VagrantPlugins
           @machine = env[:machine]
           @global_env = @machine.env
           @provider = env[:provider]
-
-          # config_global is deprecated from v1.5
-          if Gem::Version.new(::Vagrant::VERSION) >= Gem::Version.new('1.5')
-            @config = @global_env.vagrantfile.config
-          else
-            @config = @global_env.config_global
-          end
-          
+          @config = Util.get_config(@global_env)
           @logger = Log4r::Logger.new('vagrant::hostmanager::update_guest')
         end
 

--- a/lib/vagrant-hostmanager/action/update_host.rb
+++ b/lib/vagrant-hostmanager/action/update_host.rb
@@ -1,4 +1,5 @@
 require 'vagrant-hostmanager/hosts_file'
+require 'vagrant-hostmanager/util'
 
 module VagrantPlugins
   module HostManager
@@ -10,14 +11,7 @@ module VagrantPlugins
           @app = app
           @global_env = env[:global_env]
           @provider = env[:provider]
-
-          # config_global is deprecated from v1.5
-          if Gem::Version.new(::Vagrant::VERSION) >= Gem::Version.new('1.5')
-            @config = @global_env.vagrantfile.config
-          else
-            @config = @global_env.config_global
-          end
-
+          @config = Util.get_config(@global_env)
           @logger = Log4r::Logger.new('vagrant::hostmanager::update_host')
         end
 

--- a/lib/vagrant-hostmanager/provisioner.rb
+++ b/lib/vagrant-hostmanager/provisioner.rb
@@ -7,14 +7,7 @@ module VagrantPlugins
         super(machine, config)
         @global_env = machine.env
         @provider = machine.provider_name
-
-        # config_global is deprecated from v1.5
-        if Gem::Version.new(::Vagrant::VERSION) >= Gem::Version.new('1.5')
-          @config = @global_env.vagrantfile.config
-        else
-          @config = @global_env.config_global
-        end
-
+        @config = Util.get_config(@global_env)
       end
 
       def provision

--- a/lib/vagrant-hostmanager/util.rb
+++ b/lib/vagrant-hostmanager/util.rb
@@ -1,0 +1,14 @@
+module VagrantPlugins
+  module HostManager
+    module Util
+      def self.get_config(env)
+        # config_global has been removed from v1.5
+        if Gem::Version.new(::Vagrant::VERSION) >= Gem::Version.new('1.5')
+          env.vagrantfile.config
+        else
+          env.config_global
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This reduces some code duplication we had from compatibility code for vagrant < 1.5.
