### PR TITLE
New configuration feature: specify host rows with IP address.

### DIFF
--- a/lib/vagrant-hostmanager/config.rb
+++ b/lib/vagrant-hostmanager/config.rb
@@ -5,6 +5,7 @@ module VagrantPlugins
       attr_accessor :manage_host
       attr_accessor :ignore_private_ip
       attr_accessor :aliases
+      attr_accessor :alias_rows
       attr_accessor :include_offline
       attr_accessor :ip_resolver
 
@@ -18,6 +19,7 @@ module VagrantPlugins
         @ignore_private_ip  = UNSET_VALUE
         @include_offline    = UNSET_VALUE
         @aliases            = UNSET_VALUE
+        @alias_rows         = UNSET_VALUE
         @ip_resolver        = UNSET_VALUE
       end
 
@@ -27,6 +29,7 @@ module VagrantPlugins
         @ignore_private_ip  = false if @ignore_private_ip == UNSET_VALUE
         @include_offline    = false if @include_offline == UNSET_VALUE
         @aliases            = [] if @aliases == UNSET_VALUE
+        @alias_rows         = [] if @alias_rows == UNSET_VALUE
         @ip_resolver        = nil if @ip_resolver == UNSET_VALUE
 
         @aliases = [ @aliases ].flatten
@@ -58,8 +61,31 @@ module VagrantPlugins
           })
         end
 
+        if !machine.config.hostmanager.alias_rows.nil?
+          machine.config.hostmanager.alias_rows.each { |row|
+            if !row[0].kind_of?(String)
+              errors << I18n.t('vagrant_hostmanager.config.not_a_string', {
+                :config_key => 'first parameter of hostmanager.alias_rows',
+                :is_class   => row[0].class.to_s,
+              })
+            end
+
+            if !row[1].kind_of?(Hash)
+              errors << I18n.t('vagrant_hostmanager.config.not_a_hash', {
+                :config_key => 'second parameter of hostmanager.alias_rows',
+                :is_class   => row[1].class.to_s,
+              })
+            end
+          }
+        end
+
         errors.compact!
         { "HostManager configuration" => errors }
+      end
+
+      def alias(hostname, options = {})
+        @alias_rows = [] if @alias_rows == UNSET_VALUE
+        @alias_rows << [hostname, options]
       end
 
       private

--- a/lib/vagrant-hostmanager/hosts_file.rb
+++ b/lib/vagrant-hostmanager/hosts_file.rb
@@ -75,17 +75,22 @@ module VagrantPlugins
         header = "## vagrant-hostmanager-start#{id}\n"
         footer = "## vagrant-hostmanager-end\n"
         body = get_machines
-          .map { |machine| get_hosts_file_entry(machine, resolving_machine) }
+          .map { |machine| get_hosts_file_entries(machine, resolving_machine) }
           .join
         get_new_content(header, footer, body, file_content) 
       end
 
-      def get_hosts_file_entry(machine, resolving_machine)
+      def get_hosts_file_entries(machine, resolving_machine)
         ip = get_ip_address(machine, resolving_machine)
         host = machine.config.vm.hostname || machine.name
         aliases = machine.config.hostmanager.aliases.join(' ').chomp
+        alias_rows = machine.config.hostmanager.alias_rows
+          .map { |row| "#{row[1][:ip] || ip}\t#{row[0]}\n" }
+          .join
         if ip != nil
-          "#{ip}\t#{host} #{aliases}\n"
+          "#{ip}\t#{host} #{aliases}\n#{alias_rows}"
+        elsif !alias_rows.empty?
+          alias_rows
         end
       end
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,3 +8,5 @@ en:
       not_a_bool: "A value for %{config_key} can only be true or false, not type '%{value}'"
       not_an_array_or_string: "A value for %{config_key} must be an Array or String, not type '%{is_class}'"
       not_a_proc: "A value for %{config_key} must be a Proc, not type '%{is_class}'"
+      not_a_hash: "A value for %{config_key} must be a Hash, not type '%{is_class}'"
+      not_a_string: "A value for %{config_key} must be a String, not type '%{is_class}'"


### PR DESCRIPTION
I have a Vagrant configuration with multiple private networks and I needed host entries for all of them with specific IP addresses. So I added a new configuration feature that allows user to add entries with IP address.

For example:

```
Vagrant.configure("2") do |config|
    config.vm.define "example" do |server|

        server.hostmanager.alias "hostname.alias", ip: "192.168.0.1"

    end
end
```

Decided to share this if anyone else finds it useful. Of course, comments are appreciated.
