### PR TITLE
splits hostnames across many lines

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file.rb
+++ b/lib/vagrant-hostmanager/hosts_file.rb
@@ -83,9 +83,9 @@ module VagrantPlugins
       def get_hosts_file_entry(machine, resolving_machine)
         ip = get_ip_address(machine, resolving_machine)
         host = machine.config.vm.hostname || machine.name
-        aliases = machine.config.hostmanager.aliases.join(' ').chomp
+        aliases = machine.config.hostmanager.aliases
         if ip != nil
-          "#{ip}\t#{host} #{aliases}\n"
+          "#{ip}\t#{host}\n" + aliases.map{|a| "#{ip}\t#{a}"}.join("\n") + "\n"
         end
       end
 


### PR DESCRIPTION
Windows (testing on 2003) doesn't seem to like more than eight aliases per on a line.  Entries after the eigth get ignored. Splitting this back into separate lines.
