### PR TITLE
Show description for hostmanager when vagrant list-commands is triggered

### DIFF
--- a/lib/vagrant-hostmanager/command.rb
+++ b/lib/vagrant-hostmanager/command.rb
@@ -3,6 +3,11 @@ module VagrantPlugins
     class Command < Vagrant.plugin('2', :command)
       include HostsFile
 
+      # Show description when `vagrant list-commands` is triggered
+      def self.synopsis
+        "manages the /etc/hosts file within a multi-machine environment"
+      end
+
       def execute
         options = {}
         opts = OptionParser.new do |o|


### PR DESCRIPTION
Whenever you run a `vagrant list-commands` in terminal now you can see a line showing description about this precious **vagrant hostmanager** plugin like this:

``` shell
[...]
hostmanager     manages the /etc/hosts file within a multi-machine environment
[...]
```
