### PR TITLE
Allow the possibility to generate fqdn friendly /etc/hosts files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ up or have a private ip configured will be added to the hosts file.
 In addition, the `hostmanager.aliases` configuration attribute can be used
 to provide aliases for your host names.
 
+If you set the `fqdn_friendly` configuration attribute, the /etc/hosts file
+will be setup so that fully qualified domain names work properly. This fixes
+the `127.0.0.1` line so that the hostname isn't present, and if the
+`domain_name` configuration attribute is set to your domain name, it ensures
+that all the added host entries have the:
+
+```
+<ip> <fqdn> <hostname>
+```
+
+format. This is needed so that `hostname --fqdn` and `facter -p | grep fqdn`
+both work.
+
 Example configuration:
 
 ```ruby
@@ -62,6 +75,8 @@ Vagrant.configure("2") do |config|
   config.hostmanager.manage_host = true
   config.hostmanager.ignore_private_ip = false
   config.hostmanager.include_offline = true
+  config.hostmanager.fqdn_friendly = true
+  config.hostmanager.domain_name = 'example.com'
   config.vm.define 'example-box' do |node|
     node.vm.hostname = 'example-box-hostname'
     node.vm.network :private_network, ip: '192.168.42.42'

--- a/lib/vagrant-hostmanager/config.rb
+++ b/lib/vagrant-hostmanager/config.rb
@@ -7,6 +7,8 @@ module VagrantPlugins
       attr_accessor :aliases
       attr_accessor :include_offline
       attr_accessor :ip_resolver
+      attr_accessor :fqdn_friendly
+      attr_accessor :domain_name
 
       alias_method :enabled?, :enabled
       alias_method :include_offline?, :include_offline
@@ -19,6 +21,8 @@ module VagrantPlugins
         @include_offline    = UNSET_VALUE
         @aliases            = UNSET_VALUE
         @ip_resolver        = UNSET_VALUE
+        @fqdn_friendly      = UNSET_VALUE
+        @domain_name        = UNSET_VALUE
       end
 
       def finalize!
@@ -28,6 +32,8 @@ module VagrantPlugins
         @include_offline    = false if @include_offline == UNSET_VALUE
         @aliases            = [] if @aliases == UNSET_VALUE
         @ip_resolver        = nil if @ip_resolver == UNSET_VALUE
+        @fqdn_friendly      = false if @fqdn_friendly == UNSET_VALUE
+        @domain_name        = '' if @domain_name == UNSET_VALUE
 
         @aliases = [ @aliases ].flatten
       end
@@ -39,6 +45,7 @@ module VagrantPlugins
         errors << validate_bool('hostmanager.manage_host', @manage_host)
         errors << validate_bool('hostmanager.ignore_private_ip', @ignore_private_ip)
         errors << validate_bool('hostmanager.include_offline', @include_offline)
+        errors << validate_bool('hostmanager.fqdn_friendly', @fqdn_friendly)
         errors.compact!
 
         # check if aliases option is an Array


### PR DESCRIPTION
This is needed on some systems so that:

hostname --fqdn

and

facter -p | grep fqdn

both return something useful.

This patch adds the fqdn_friendly and domain_name configuration options.