### PR TITLE
Feat/extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ up or have a private ip configured will be added to the hosts file.
 In addition, the `hostmanager.aliases` configuration attribute can be used
 to provide aliases for your host names.
 
+If you set the `fqdn_friendly` configuration attribute, the /etc/hosts file
+will be setup so that fully qualified domain names work properly. This fixes
+the `127.0.0.1` line so that the hostname isn't present, and if the
+`domain_name` configuration attribute is set to your domain name, it ensures
+that all the added host entries have the:
+
+```
+<ip> <fqdn> <hostname>
+```
+
+format. This is needed so that `hostname --fqdn` and `facter -p | grep fqdn`
+both work.
+
 Example configuration:
 
 ```ruby
@@ -62,6 +75,8 @@ Vagrant.configure("2") do |config|
   config.hostmanager.manage_host = true
   config.hostmanager.ignore_private_ip = false
   config.hostmanager.include_offline = true
+  config.hostmanager.fqdn_friendly = true
+  config.hostmanager.domain_name = 'example.com'
   config.vm.define 'example-box' do |node|
     node.vm.hostname = 'example-box-hostname'
     node.vm.network :private_network, ip: '192.168.42.42'

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ that all the added host entries have the:
 format. This is needed so that `hostname --fqdn` and `facter -p | grep fqdn`
 both work.
 
+If you set the `extra_hosts` configuration attribute, each hash in that list
+will be used to add additional elements to each /etc/hosts file. This is useful
+for defining a virtual IP, which doesn't correspond to a particular physical
+host, but which requires a DNS entry. Each element in the `extra_hosts` list
+should be a hash with three keys: `:ip`, `:host`, and `:aliases`. The first two
+should be strings, while the third should be a list of strings.
+
 Example configuration:
 
 ```ruby
@@ -77,6 +84,13 @@ Vagrant.configure("2") do |config|
   config.hostmanager.include_offline = true
   config.hostmanager.fqdn_friendly = true
   config.hostmanager.domain_name = 'example.com'
+  config.hostmanager.extra_hosts = [
+    {
+      :host => 'vip.example.com',
+      :ip => '192.168.42.253',
+      :aliases => ['vip'],
+    },
+  ]
   config.vm.define 'example-box' do |node|
     node.vm.hostname = 'example-box-hostname'
     node.vm.network :private_network, ip: '192.168.42.42'

--- a/lib/vagrant-hostmanager/config.rb
+++ b/lib/vagrant-hostmanager/config.rb
@@ -9,6 +9,7 @@ module VagrantPlugins
       attr_accessor :ip_resolver
       attr_accessor :fqdn_friendly
       attr_accessor :domain_name
+      attr_accessor :extra_hosts
 
       alias_method :enabled?, :enabled
       alias_method :include_offline?, :include_offline
@@ -23,6 +24,7 @@ module VagrantPlugins
         @ip_resolver        = UNSET_VALUE
         @fqdn_friendly      = UNSET_VALUE
         @domain_name        = UNSET_VALUE
+        @extra_hosts        = UNSET_VALUE
       end
 
       def finalize!
@@ -34,6 +36,7 @@ module VagrantPlugins
         @ip_resolver        = nil if @ip_resolver == UNSET_VALUE
         @fqdn_friendly      = false if @fqdn_friendly == UNSET_VALUE
         @domain_name        = '' if @domain_name == UNSET_VALUE
+        @extra_hosts        = [] if @extra_hosts == UNSET_VALUE
 
         @aliases = [ @aliases ].flatten
       end

--- a/lib/vagrant-hostmanager/config.rb
+++ b/lib/vagrant-hostmanager/config.rb
@@ -7,6 +7,8 @@ module VagrantPlugins
       attr_accessor :aliases
       attr_accessor :include_offline
       attr_accessor :ip_resolver
+      attr_accessor :fqdn_friendly
+      attr_accessor :domain_name
 
       alias_method :enabled?, :enabled
       alias_method :include_offline?, :include_offline
@@ -19,6 +21,8 @@ module VagrantPlugins
         @include_offline    = UNSET_VALUE
         @aliases            = UNSET_VALUE
         @ip_resolver        = UNSET_VALUE
+        @fqdn_friendly      = UNSET_VALUE
+        @domain_name        = UNSET_VALUE
       end
 
       def finalize!
@@ -28,6 +32,8 @@ module VagrantPlugins
         @include_offline    = false if @include_offline == UNSET_VALUE
         @aliases            = [] if @aliases == UNSET_VALUE
         @ip_resolver        = nil if @ip_resolver == UNSET_VALUE
+        @fqdn_friendly      = false if @fqdn_friendly == UNSET_VALUE
+        @domain_name        = '' if @domain_name == UNSET_VALUE
 
         @aliases = [ @aliases ].flatten
       end
@@ -39,6 +45,7 @@ module VagrantPlugins
         errors << validate_bool('hostmanager.manage_host', @manage_host)
         errors << validate_bool('hostmanager.ignore_private_ip', @ignore_private_ip)
         errors << validate_bool('hostmanager.include_offline', @include_offline)
+        errors << validate_bool('hostmanager.fqdn_friendly', @fqdn_friendly)
         errors.compact!
 
         # check if aliases option is an Array

--- a/lib/vagrant-hostmanager/hosts_file/updater.rb
+++ b/lib/vagrant-hostmanager/hosts_file/updater.rb
@@ -143,10 +143,16 @@ module VagrantPlugins
         end
 
         def get_new_content(header, footer, body, old_content)
+
+          extras = ''
+          @config.hostmanager.extra_hosts.each do |x|
+            extras+= ("#{x[:ip]}\t#{x[:host]}\t" + x[:aliases].join("\t") + "\n")
+          end
+
           if body.empty?
-            block = "\n"
+            block = "\n" + extras
           else
-            block = "\n\n" + header + body + footer + "\n"
+            block = "\n\n" + header + body + extras + footer + "\n"
           end
           # Pattern for finding existing block
           header_pattern = Regexp.quote(header)


### PR DESCRIPTION
This patch adds support for adding additional `/etc/hosts` entries, which aren't present in vagrant. It is necessary for VIP's, or for simply listing hosts that you want to include in your `/etc/hosts` faked "DNS".

This patch is based off of my earlier feature: https://github.com/smdahlen/vagrant-hostmanager/pull/109

If you'd like it rebased off of master, I can do that, but it makes sense to merge the other one first, and then this one.

Cheers,
James
