### PR TITLE
make separating aliases into multiple lines optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ up or have a private ip configured will be added to the hosts file.
 In addition, the `hostmanager.aliases` configuration attribute can be used
 to provide aliases for your host names.
 
+On some systems, long alias lines have been reported to cause issues
+(see [#60](https://github.com/smdahlen/vagrant-hostmanager/issues/60)).
+In such cases, you may render aliases on separate lines by setting
+```hostmanager.aliases_on_separate_lines = true```.
+
 Example configuration:
 
 ```ruby

--- a/lib/vagrant-hostmanager/config.rb
+++ b/lib/vagrant-hostmanager/config.rb
@@ -7,6 +7,7 @@ module VagrantPlugins
       attr_accessor :aliases
       attr_accessor :include_offline
       attr_accessor :ip_resolver
+      attr_accessor :aliases_on_separate_lines
 
       alias_method :enabled?, :enabled
       alias_method :include_offline?, :include_offline
@@ -19,6 +20,7 @@ module VagrantPlugins
         @include_offline    = UNSET_VALUE
         @aliases            = UNSET_VALUE
         @ip_resolver        = UNSET_VALUE
+        @aliases_on_separate_lines   = UNSET_VALUE
       end
 
       def finalize!
@@ -28,6 +30,7 @@ module VagrantPlugins
         @include_offline    = false if @include_offline == UNSET_VALUE
         @aliases            = [] if @aliases == UNSET_VALUE
         @ip_resolver        = nil if @ip_resolver == UNSET_VALUE
+        @aliases_on_separate_lines   = false if @aliases_on_separate_lines == UNSET_VALUE
 
         @aliases = [ @aliases ].flatten
       end

--- a/lib/vagrant-hostmanager/hosts_file/updater.rb
+++ b/lib/vagrant-hostmanager/hosts_file/updater.rb
@@ -93,8 +93,19 @@ module VagrantPlugins
           ip = get_ip_address(machine, resolving_machine)
           host = machine.config.vm.hostname || machine.name
           aliases = machine.config.hostmanager.aliases
+
           if ip != nil
-            "#{ip}\t#{host}\n" + aliases.map{|a| "#{ip}\t#{a}"}.join("\n") + "\n"
+            # As per GH-60, we optionally render aliases on separate lines
+            current_machine_config = ((resolving_machine && resolving_machine.config) || @config)            
+            if current_machine_config.hostmanager.aliases_on_separate_lines
+              rendered_aliases = aliases.map { |a| "#{ip}\t#{a}" }.join("\n")
+              separator = "\n"
+            else
+              rendered_aliases = aliases.join(" ")
+              separator = "\t"
+            end
+
+            "#{ip}\t#{host}" + separator + rendered_aliases + "\n"
           end
         end
 

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -16,16 +16,19 @@ Vagrant.configure('2') do |config|
 
   config.hostmanager.enabled = true
   config.hostmanager.manage_host = true
+  # config.hostmanager.aliases_on_separate_lines = true
 
   config.vm.define :server1 do |server|
     server.vm.hostname = 'fry'
     server.vm.network :private_network, :ip => '10.0.5.2'
-    server.hostmanager.aliases = %w(test-alias)
+    server.hostmanager.aliases = %w(alias1 alias2)
   end
 
   config.vm.define :server2 do |server|
     server.vm.hostname = 'bender'
     server.vm.network :private_network, :ip => '10.0.5.3'
+    server.hostmanager.aliases = %w(alias3 alias4)
+    server.hostmanager.aliases_on_separate_lines = true
   end
 
   config.vm.define :server3 do |server|


### PR DESCRIPTION
In #103 we started splitting aliases into multiple lines, to solve #60.  Instead of hard-coding this behavior, it should be optional.