### PR TITLE
add config value to set full path to cp on POSIX systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ accordingly. Set the `hostmanager.enabled` attribute to `true` in the
 Vagrantfile to activate this behavior.
 
 To update the host's `/etc/hosts` file, set the `hostmanager.manage_host`
-attribute to `true`.
+attribute to `true`. On POSIX systems cp is used to manage this file. The
+path to cp on your system can given by setting `hostmanager.path_to_cp` 
+to something like `/bin/cp` (default value).
 
 A machine's IP address is defined by either the static IP for a private
 network configuration or by the SSH host configuration. To disable
@@ -62,6 +64,8 @@ Vagrant.configure("2") do |config|
   config.hostmanager.manage_host = true
   config.hostmanager.ignore_private_ip = false
   config.hostmanager.include_offline = true
+  config.hostmanager.path_to_cp = "/bin/cp"
+
   config.vm.define 'example-box' do |node|
     node.vm.hostname = 'example-box-hostname'
     node.vm.network :private_network, ip: '192.168.42.42'

--- a/lib/vagrant-hostmanager/config.rb
+++ b/lib/vagrant-hostmanager/config.rb
@@ -1,3 +1,5 @@
+require 'rbconfig'
+
 module VagrantPlugins
   module HostManager
     class Config < Vagrant.plugin('2', :config)
@@ -7,6 +9,7 @@ module VagrantPlugins
       attr_accessor :aliases
       attr_accessor :include_offline
       attr_accessor :ip_resolver
+      attr_accessor :path_to_cp
 
       alias_method :enabled?, :enabled
       alias_method :include_offline?, :include_offline
@@ -19,6 +22,7 @@ module VagrantPlugins
         @include_offline    = UNSET_VALUE
         @aliases            = UNSET_VALUE
         @ip_resolver        = UNSET_VALUE
+        @path_to_cp         = '/bin/cp'
       end
 
       def finalize!
@@ -28,6 +32,7 @@ module VagrantPlugins
         @include_offline    = false if @include_offline == UNSET_VALUE
         @aliases            = [] if @aliases == UNSET_VALUE
         @ip_resolver        = nil if @ip_resolver == UNSET_VALUE
+        @path_to_cp         = nil if @path_to_cp == UNSET_VALUE
 
         @aliases = [ @aliases ].flatten
       end
@@ -39,6 +44,9 @@ module VagrantPlugins
         errors << validate_bool('hostmanager.manage_host', @manage_host)
         errors << validate_bool('hostmanager.ignore_private_ip', @ignore_private_ip)
         errors << validate_bool('hostmanager.include_offline', @include_offline)
+        if !RbConfig::CONFIG['host_os'].match('windows')
+          errors << validate_path_to_file('hostmanager.path_to_cp', @path_to_cp)
+        end
         errors.compact!
 
         # check if aliases option is an Array
@@ -75,6 +83,19 @@ module VagrantPlugins
           nil
         end
       end
+
+      def validate_path_to_file(key, value)
+        if !File.file?(value) &&
+           value != UNSET_VALUE
+          I18n.t('vagrant_hostmanager.config.not_a_file', {
+            :config_key => key,
+            :value      => value
+          })
+        else
+          nil
+        end
+      end
+
     end
   end
 end

--- a/lib/vagrant-hostmanager/hosts_file/updater.rb
+++ b/lib/vagrant-hostmanager/hosts_file/updater.rb
@@ -60,7 +60,7 @@ module VagrantPlugins
             copy_proc = Proc.new { windows_copy_file(file, hosts_location) }
           else
             hosts_location = '/etc/hosts'
-            copy_proc = Proc.new { `sudo cp #{file} #{hosts_location}` }
+            copy_proc = Proc.new { `sudo #{@config.hostmanager.path_to_cp} #{file} #{hosts_location}` }
           end
 
           FileUtils.cp(hosts_location, file)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,3 +8,4 @@ en:
       not_a_bool: "A value for %{config_key} can only be true or false, not type '%{value}'"
       not_an_array_or_string: "A value for %{config_key} must be an Array or String, not type '%{is_class}'"
       not_a_proc: "A value for %{config_key} must be a Proc, not type '%{is_class}'"
+      not_a_file: "A value for %{config_key} can only be a real filesystem path on this host, '%{value}'' is not"


### PR DESCRIPTION
to be able to set a Cmnd_Alias to something like `/bin/cp /home/user/.vagrant.d/tmp/hosts.local /etc/hosts` the command needs to be called with this exact same path, and not only by `cp`(sudo security dictates that full path to binaries must be given).

Furthermore `cp` might live in different locations on different systems.

This pull request is my suggestion on how to fix that. I hope it is useful :)

/Lasse