### PR TITLE
Add example to readme demonstrating host-manager usage with dynamic IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ end
 
 ### Using with DHCP
 
-Sometimes the development box's ip isn't needed, and just assigning it a domain is all that is needed.  If that's the case vagrant can rely on DHCP to assign the IP, and vagrant-hostmanager to setup the hosts file.  Below is an example of this.
+Sometimes the development box's ip isn't needed, and just assigning it a domain is all that is required.  If that's the case vagrant can rely on DHCP to assign the IP, and vagrant-hostmanager to setup the hosts file.  
+The below example creates a vagrant box with a dynamically allocated IP, then queries the box for the IP to add to the host computer's hosts file, associating the domain 'development-test.local' with the vagrant box's IP.
 
 ```ruby
 Vagrant.configure(2) do |config|

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Vagrant.configure(2) do |config|
             ifconfigIPs = buffer.scan(/inet addr:(\d+\.\d+\.\d+\.\d+)/)
             ifconfigIPs[0..ifconfigIPs.size].each do |ip|
                 ip = ip.first
-                next if ip =~ /(^127\.0\.0\.1)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/
+
+                next unless system "ping -c1 -t1 #{ip} > /dev/null"
 
                 ips.push(ip) unless ips.include? ip
             end


### PR DESCRIPTION
Adds an example to the readme which demonstrates how a dynamic IP can be used on a vagrant box, and the IP can be retrieved and assigned to a domain using host-manager.

Not 100% on the verbiage or example code, but I think the idea is solid and should be in the readme, in some form.