### PR TITLE
Provisioner should update all hosts

### DIFF
--- a/lib/vagrant-hostmanager/provisioner.rb
+++ b/lib/vagrant-hostmanager/provisioner.rb
@@ -12,7 +12,12 @@ module VagrantPlugins
       end
 
       def provision
-        @updater.update_guest(@machine)
+        @global_env.active_machines.each do |name, p|
+          if p == @provider
+            machine = @global_env.machine(name, p)
+            @updater.update_guest(machine)
+          end
+        end
         if @config.hostmanager.manage_host?
           @updater.update_host
         end


### PR DESCRIPTION
This would be useful because when a new machine is created/provisioned, it makes sense that it be added to all the other machines' hostfiles, allowing them to communicate with it.
If a machine is reloaded and gets a new IP, and the host-manager provisioner is set to always run, it'd also be beneficial for the provisioner to update the IP on all hosts, not just the one being reloaded and possibly master.

If possible, this would be a good provisioner option, something like `config.vm.provision 'hostmanager', update: "all", run: "always"`.  I don't know how to accomplish this though, I'm new to Vagrant plugins.