### PR TITLE
Improve README.md for Passwordless sudo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,31 @@ end
 Passwordless sudo
 -----------------
 
-Add  the  following snippet  to  the  sudoers  file (for  example,  to
-```/etc/sudoers.d/vagrant_hostmanager```)  to  make   it  stop  asking
-password when updating hosts  file (replace ```/home/user``` with your
-actual home directory):
+To avoid being asked for the password every time the hosts file is updated,
+enable passwordless sudo for the specific command that hostmanager uses to
+update the hosts file.
 
-    Cmnd_Alias VAGRANT_HOSTMANAGER_UPDATE = /bin/cp /home/user/.vagrant.d/tmp/hosts.local /etc/hosts
-    %sudo ALL=(root) NOPASSWD: VAGRANT_HOSTMANAGER_UPDATE
+  - Add the following snippet to the sudoers file (e.g.
+    `/etc/sudoers.d/vagrant_hostmanager`):
+
+    ```
+    Cmnd_Alias VAGRANT_HOSTMANAGER_UPDATE = /bin/cp <home-directory>/.vagrant.d/tmp/hosts.local /etc/hosts
+    %<admin-group> ALL=(root) NOPASSWD: VAGRANT_HOSTMANAGER_UPDATE
+    ```
+
+    Replace `<home-directory>` with your actual home directory (e.g.
+    `/home/joe`) and `<admin-group>` with the group that is used by the system
+    for sudo access (usually `sudo` on Debian/Ubuntu systems and `wheel`
+    on Fedora/Red Hat systems).
+
+  - If necessary, add yourself to the `<admin-group>`:
+
+    ```
+    usermod -aG <admin-group> <user-name>
+    ```
+
+    Replace `<admin-group>` with the group that is used by the system for sudo
+    access (see above) and `<user-name>` with you user name.
 
 Windows support
 ---------------


### PR DESCRIPTION
Add information that the usual sudo group on Fedora/Red Hat systems is
named 'wheel'.
Generalize instructions to make them distribution-agnostic.
Add step on adding yourself to the administrator group.