### PR TITLE
Prevent wiping of addresses of other providers

### DIFF
--- a/lib/vagrant-hostmanager/hosts_file/updater.rb
+++ b/lib/vagrant-hostmanager/hosts_file/updater.rb
@@ -82,8 +82,8 @@ module VagrantPlugins
 
         def update_content(file_content, resolving_machine, include_id)
           id = include_id ? " id: #{read_or_create_id}" : ""
-          header = "## vagrant-hostmanager-start#{id}\n"
-          footer = "## vagrant-hostmanager-end\n"
+          header = "## vagrant-hostmanager-start-#{@provider}#{id}\n"
+          footer = "## vagrant-hostmanager-end-#{@provider}\n"
           body = get_machines
             .map { |machine| get_hosts_file_entry(machine, resolving_machine) }
             .join


### PR DESCRIPTION
Hostmanager can only deal with one provider at a time.

If you `vagrant up` a virtualbox vm, then an aws, all information
of your virtulabox vm will be removed from /etc/hosts on the host.

By adding the provider type in the header/footer of the hostmanager
section of /etc/hosts, we can have one section per provider and
thus keep all machines, no matter the provider.