### PR TITLE
use the scoped config block when running as a provisioner instead of trying to get the global config

### DIFF
--- a/lib/vagrant-hostmanager/provisioner.rb
+++ b/lib/vagrant-hostmanager/provisioner.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
       def initialize(machine, config)
         super(machine, config)
         global_env = machine.env
-        @config = Util.get_config(global_env)
+        @config = config
         @updater = HostsFile::Updater.new(global_env, machine.provider_name)
       end
 


### PR DESCRIPTION
We have separate hostmanager configuration stanzas for different Providers; right now, if you set a hostmanager config on a provider's override block, it is completely ignored.

This patch fixes it.

I'm not sure if there's some subtle reason that I missed; if so, please let me know and we can brainstorm some other way to fix it.

Example config:

```
Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.box = "some-box-name"
  config.hostmanager.ip_resolver = default_proc_used_on_default_provisioner

  config.vm.provider "virtualbox" do |vb, override|
    override.hostmanager.ip_resolver = some_other_proc
  end
end
```
